### PR TITLE
fixed event for transfer

### DIFF
--- a/src/Echo.sol
+++ b/src/Echo.sol
@@ -14,7 +14,7 @@ error InvalidAssets();
 error InvalidPayment();
 
 contract Echo is ReentrancyGuard, Admin, Handler, Banker, Signer {
-    event TradeExecuted(address indexed owner, address indexed counterparty, string id);
+    event TradeExecuted(string id);
 
     constructor(address owner) Admin(owner) {}
 
@@ -73,6 +73,6 @@ contract Echo is ReentrancyGuard, Admin, Handler, Banker, Signer {
         // Add trade to list to avoid replay and duplicates
         trades[trade.id] = true;
 
-        emit TradeExecuted(msg.sender, trade.counterparty, trade.id);
+        emit TradeExecuted(trade.id);
     }
 }

--- a/src/Echo.sol
+++ b/src/Echo.sol
@@ -14,7 +14,7 @@ error InvalidAssets();
 error InvalidPayment();
 
 contract Echo is ReentrancyGuard, Admin, Handler, Banker, Signer {
-    event TradeExecuted(string indexed id, address user);
+    event TradeExecuted(address indexed owner, address indexed counterparty, string id);
 
     constructor(address owner) Admin(owner) {}
 
@@ -73,6 +73,6 @@ contract Echo is ReentrancyGuard, Admin, Handler, Banker, Signer {
         // Add trade to list to avoid replay and duplicates
         trades[trade.id] = true;
 
-        emit TradeExecuted(trade.id, msg.sender);
+        emit TradeExecuted(msg.sender, trade.counterparty, trade.id);
     }
 }

--- a/test/Approval.t.sol
+++ b/test/Approval.t.sol
@@ -83,7 +83,7 @@ contract ApprovalTest is BaseTest {
 
         vm.prank(account1);
         vm.expectEmit(true, true, true, true);
-        emit TradeExecuted("test", account1);
+        emit TradeExecuted(account1, account2, "test");
         echo.executeTrade(v, r, s, trade);
 
         // Assets are now swapped

--- a/test/Approval.t.sol
+++ b/test/Approval.t.sol
@@ -83,7 +83,7 @@ contract ApprovalTest is BaseTest {
 
         vm.prank(account1);
         vm.expectEmit(true, true, true, true);
-        emit TradeExecuted(account1, account2, "test");
+        emit TradeExecuted("test");
         echo.executeTrade(v, r, s, trade);
 
         // Assets are now swapped

--- a/test/BaseTest.t.sol
+++ b/test/BaseTest.t.sol
@@ -10,7 +10,7 @@ abstract contract BaseTest is Test {
     // Exclude from coverage report
     function test() public {}
 
-    event TradeExecuted(address indexed owner, address indexed counterparty, string id);
+    event TradeExecuted(string id);
 
     Echo echo;
     // To test internal function as it's impossible to reach the code

--- a/test/BaseTest.t.sol
+++ b/test/BaseTest.t.sol
@@ -10,7 +10,7 @@ abstract contract BaseTest is Test {
     // Exclude from coverage report
     function test() public {}
 
-    event TradeExecuted(string indexed id, address user);
+    event TradeExecuted(address indexed owner, address indexed counterparty, string id);
 
     Echo echo;
     // To test internal function as it's impossible to reach the code

--- a/test/Trade721.t.sol
+++ b/test/Trade721.t.sol
@@ -91,7 +91,7 @@ contract Trade721Test is BaseTest {
 
         vm.prank(account1);
         vm.expectEmit(true, true, true, true);
-        emit TradeExecuted(account1, account2, "test");
+        emit TradeExecuted("test");
         echo.executeTrade(v, r, s, trade);
 
         // Assets are now swapped
@@ -123,7 +123,7 @@ contract Trade721Test is BaseTest {
 
         vm.prank(account1);
         vm.expectEmit(true, true, true, true);
-        emit TradeExecuted(account1, account2, "test");
+        emit TradeExecuted("test");
         echo.executeTrade(v, r, s, trade);
 
         // Assets are now swapped
@@ -157,7 +157,7 @@ contract Trade721Test is BaseTest {
 
         vm.prank(account1);
         vm.expectEmit(true, true, true, true);
-        emit TradeExecuted(account1, account2, "test");
+        emit TradeExecuted("test");
         echo.executeTrade(v, r, s, trade);
 
         // Assets are now swapped

--- a/test/Trade721.t.sol
+++ b/test/Trade721.t.sol
@@ -91,7 +91,7 @@ contract Trade721Test is BaseTest {
 
         vm.prank(account1);
         vm.expectEmit(true, true, true, true);
-        emit TradeExecuted("test", account1);
+        emit TradeExecuted(account1, account2, "test");
         echo.executeTrade(v, r, s, trade);
 
         // Assets are now swapped
@@ -123,7 +123,7 @@ contract Trade721Test is BaseTest {
 
         vm.prank(account1);
         vm.expectEmit(true, true, true, true);
-        emit TradeExecuted("test", account1);
+        emit TradeExecuted(account1, account2, "test");
         echo.executeTrade(v, r, s, trade);
 
         // Assets are now swapped
@@ -157,7 +157,7 @@ contract Trade721Test is BaseTest {
 
         vm.prank(account1);
         vm.expectEmit(true, true, true, true);
-        emit TradeExecuted("test", account1);
+        emit TradeExecuted(account1, account2, "test");
         echo.executeTrade(v, r, s, trade);
 
         // Assets are now swapped


### PR DESCRIPTION
When indexing an arg on a contract, if it's a string, it will be `keccak256` first which makes the string unrecoverable.
Removed the index for it, added the `owner` and `counterparty` indexed.